### PR TITLE
com.utilities.encoder.ogg 3.0.8

### DIFF
--- a/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/Runtime/OggEncoder.cs
+++ b/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/Runtime/OggEncoder.cs
@@ -7,15 +7,19 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Scripting;
 using Utilities.Async;
 using Utilities.Audio;
-using Random = System.Random;
 using Microphone = Utilities.Audio.Microphone;
+using Random = System.Random;
 
 namespace Utilities.Encoding.OggVorbis
 {
     public class OggEncoder : IEncoder
     {
+        [Preserve]
+        public OggEncoder() { }
+
         public static float[][] ConvertPcmData(int outputSampleRate, int outputChannels, byte[] pcmSamples, int pcmSampleRate, int pcmChannels)
         {
             var numPcmSamples = pcmSamples.Length / sizeof(short) / pcmChannels;

--- a/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/package.json
+++ b/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Encoder.Ogg",
   "description": "Simple library for Ogg encoding support.",
   "keywords": [],
-  "version": "3.0.7",
+  "version": "3.0.8",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.ogg#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.ogg/releases",


### PR DESCRIPTION
- fixed an issue with default .ctr being stripped from builds