### PR TITLE
com.utilities.encoder.ogg 4.0.1

### DIFF
--- a/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/Runtime/OggEncoder.cs
+++ b/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/Runtime/OggEncoder.cs
@@ -139,7 +139,7 @@ namespace Utilities.Encoding.OggVorbis
                 }
 
                 var totalSampleCount = 0;
-                var finalSamples = new float[clipData.MaxSamples];
+                var finalSamples = new float[clipData.MaxSamples ?? clipData.SampleRate * RecordingManager.MaxRecordingLength];
 
                 try
                 {
@@ -191,6 +191,7 @@ namespace Utilities.Encoding.OggVorbis
 
                             if (samplesToWrite > 0)
                             {
+                                cancellationToken.ThrowIfCancellationRequested();
                                 clipData.Clip.GetData(sampleBuffer, 0);
 
                                 for (var i = 0; i < samplesToWrite; i++)

--- a/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/package.json
+++ b/com.utilities.encoder.ogg/Packages/com.com.utilities.encoder.ogg/package.json
@@ -3,7 +3,7 @@
   "displayName": "Utilities.Encoder.Ogg",
   "description": "Simple library for Ogg encoding support.",
   "keywords": [],
-  "version": "4.0.0",
+  "version": "4.0.1",
   "unity": "2021.3",
   "documentationUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.ogg#documentation",
   "changelogUrl": "https://github.com/RageAgainstThePixel/com.utilities.encoder.ogg/releases",
@@ -15,7 +15,7 @@
   "author": "Stephen Hodgson",
   "url": "https://github.com/StephenHodgson",
   "dependencies": {
-    "com.utilities.audio": "2.0.1"
+    "com.utilities.audio": "2.0.2"
   },
   "samples": [
     {


### PR DESCRIPTION
- fixed a missing reference exception when cancelling streaming audio only
- com.utilities.audio -> 2.0.2